### PR TITLE
Remove gatsby-plugin-google-analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,13 +36,6 @@ module.exports = {
   },
   pathPrefix: "/",
   plugins: [
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: "UA-157758997-1",
-        head: true,
-      },
-    },
     "gatsby-plugin-react-helmet",
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8160,14 +8160,6 @@
         "micromatch": "^3.1.10"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.35.tgz",
-      "integrity": "sha512-csZc0LgpMAw0cD27zpGKYHw41veYLLjoxT2guTY1hC3/tMRNZ38XUvO4TKcFGjgobppOg/UuLNF31YzjwJRmpA==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "gatsby-plugin-manifest": {
       "version": "2.2.40",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.40.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "gatsby": "^2.16.1",
     "gatsby-cli": "^2.4.3",
     "gatsby-image": "^2.0.15",
-    "gatsby-plugin-google-analytics": "^2.1.35",
     "gatsby-plugin-manifest": "^2.0.5",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",


### PR DESCRIPTION
Remove gatsby-plugin-google-analytics plugin to apply CNIL policies.
